### PR TITLE
[BFCL] update tree_sitter version in requirements.txt (#433)

### DIFF
--- a/berkeley-function-call-leaderboard/requirements.txt
+++ b/berkeley-function-call-leaderboard/requirements.txt
@@ -1,6 +1,6 @@
 requests
 tqdm
-tree_sitter
+tree_sitter~=0.21.0
 torch 
 ray
 shortuuid


### PR DESCRIPTION
Following the instructions in the `BFCL` README and running the `eval_data_compilation.py` script results in this error:

```
AttributeError: type object 'tree_sitter.Language' has no attribute 'build_library'
```

because the `build_library` method was removed in a [recent release](https://github.com/tree-sitter/py-tree-sitter/releases/tag/v0.22.0) of py-tree-sitter. This PR updates the `requirements.txt` file so that the instructions in the README will work for anyone following them now.