### PR TITLE
Fix breaking changes due to updated Anthropic SDK (#452)

### DIFF
--- a/berkeley-function-call-leaderboard/model_handler/claude_fc_handler.py
+++ b/berkeley-function-call-leaderboard/model_handler/claude_fc_handler.py
@@ -1,18 +1,20 @@
-from model_handler.handler import BaseHandler
+import json
+import os
+import time
+
 from anthropic import Anthropic
-from anthropic.types import TextBlock
-from anthropic.types.beta.tools import ToolUseBlock
-from model_handler.model_style import ModelStyle
+from anthropic.types import TextBlock, ToolUseBlock
 from model_handler.claude_prompt_handler import ClaudePromptingHandler
-from model_handler.utils import (
-    convert_to_tool,
-    augment_prompt_by_languge,
-    language_specific_pre_processing,
-    ast_parse,
-    convert_to_function_call
-)
 from model_handler.constant import GORILLA_TO_OPENAPI
-import os, time, json
+from model_handler.handler import BaseHandler
+from model_handler.model_style import ModelStyle
+from model_handler.utils import (
+    ast_parse,
+    augment_prompt_by_languge,
+    convert_to_function_call,
+    convert_to_tool,
+    language_specific_pre_processing,
+)
 
 
 class ClaudeFCHandler(BaseHandler):
@@ -52,7 +54,7 @@ class ClaudeFCHandler(BaseHandler):
                     tool_call_outputs.append({content.name: json.dumps(content.input)})
             result =  tool_call_outputs if tool_call_outputs else text_outputs[0]
             return result, {"input_tokens": response.usage.input_tokens, "output_tokens": response.usage.output_tokens, "latency": latency}
-    
+
     def decode_ast(self,result,language="Python"):
         if "FC" not in self.model_name:
             decoded_output = ast_parse(result,language)
@@ -69,7 +71,7 @@ class ClaudeFCHandler(BaseHandler):
                         params[key] = str(params[key])
                 decoded_output.append({name: params})
         return decoded_output
-    
+
     def decode_execute(self,result):
         if "FC" not in self.model_name:
             decoded_output = ast_parse(result)


### PR DESCRIPTION
Anthropic just moved their tool use from beta to main so we have to change the import `from anthropic.types.beta.tools import ToolUseBlock` to `from anthropic.types import ToolUseBlock`. You cannot run the eval without this change as things break.

Also, my IDE automatically sorted the imported packages and removed some extra spaces -- this explains all the other changes.